### PR TITLE
Aggiunta funzione ausiliaria per verificare i campi obbligatori

### DIFF
--- a/modules/system/Pi_Settings/call/DB/Win_Edit_MYSQL.php
+++ b/modules/system/Pi_Settings/call/DB/Win_Edit_MYSQL.php
@@ -7,7 +7,7 @@
 	}else{
 		$oldID = '';
 		$fill = Array(
-			'des' => 'Nuovo DB', 
+			'des' => 'Nuovo DB',
 			'DB' => 'MYSQL',
 			'server' => '',
 			'dbuser' => '',
@@ -19,13 +19,13 @@
 		);
 		$delButton='';
 	}
-	
+
 	if($isUsed){
 		$txtMod = '<br><b><i18n>db:iface:undelConnUsed</i18n></b>';
 	}else{
 		$txtMod = '';
 	}
-	
+
 	$out = '<div id="Win_Edit">
 		<div class="focus purple">
 			<i18n>db:conn:mysqlInfo</i18n>'.$txtMod.'
@@ -78,8 +78,9 @@
 			</tr>
 		</table>
 		</div>';
-		
-	$footer = '<button class="red" onclick="pi.win.close();"> <i18n>cancel</i18n></button>'.$delButton.'<button class="green" onclick="pi.requestOnModal(\'Win_Edit\',\'DB/Save_MYSQL\')"><i18n>save</i18n></button>';
-	
+
+	$footer = '<button class="red" onclick="pi.win.close();"> <i18n>cancel</i18n></button>'.$delButton.'<button class="green"
+		onclick="pi.chk(function(){return mandatoryFieldsChk([{name:\'id\',label:\'UID\'}])}).requestOnModal(\'Win_Edit\',\'DB/Save_MYSQL\')"><i18n>save</i18n></button>';
+
 	$pr->addWindow(600,0,'<i18n>db:conn:mysql</i18n>',$out,$footer)->addScript('$("#WinEditFocus").focus();')->addFill('Win_Edit',$fill)->response();
 ?>

--- a/modules/system/Pi_Settings/script.js
+++ b/modules/system/Pi_Settings/script.js
@@ -1,10 +1,10 @@
 shortcut('esc', function(){pi.win.close();});
 
-function onEnterUsr(){ pi.request('cerca_utente'); }	
-function onEnterMod(){ pi.request('cerca_modulo'); }	
-function onEnterGrp(){ pi.request('cerca_gruppo'); }	
-function onEnterMenu(){ pi.request('cerca_menu'); }	
-function onEnterDB(){ pi.request('cerca_db'); }	
+function onEnterUsr(){ pi.request('cerca_utente'); }
+function onEnterMod(){ pi.request('cerca_modulo'); }
+function onEnterGrp(){ pi.request('cerca_gruppo'); }
+function onEnterMenu(){ pi.request('cerca_menu'); }
+function onEnterDB(){ pi.request('cerca_db'); }
 
 function modReplaceIco(obj){
 	var elem = $('#anchor_img_to_save');
@@ -50,5 +50,60 @@ function menuFilterMod(){
 			list[i].style.display = 'table-row';
 		}
 	}
-	
+
+}
+
+function mandatoryFieldsChk(mandatoryFields){
+	/*
+	mandatoryFields (Array of Objects):
+	Array of mandatory fields
+	e.g.:
+	[
+		{
+			"name": "id",
+			"label":"UID"
+		}
+	]
+	*/
+	if (typeof(mandatoryFields) != "object") {
+		console.error("mandatoryFields should be an Array of Objects.");
+		mandatoryFields = [mandatoryFields];
+	}
+	var validation = true;
+	var missingFieldsList = "";
+
+	for (i in mandatoryFields) {
+		if (typeof(mandatoryFields[i]) != "object") {
+			console.error("Items in mandatoryFields Array should be Objects.");
+			mandatoryFields[i] = {
+				"name":mandatoryFields[i]
+			};
+		}
+		const name = mandatoryFields[i].name;
+		const selector = "input[name='" + name + "']";
+		const $selected = $(selector);
+		if (!$selected.length) {
+			console.error("Field named "+ name + " doesn't exist.");
+			continue;
+		}
+		if ($selected.val() == "") {
+			validation = false;
+			if (mandatoryFields[i].label === undefined) {
+			/*
+			if no label is given, we suppose that input fields are wrapped in <td></td>
+			and its the label is in the previous <th></th>
+			*/
+				mandatoryFields[i].label = $selected.parent().prev().text();
+			}
+			missingFieldsList += mandatoryFields[i].label;
+			missingFieldsList += "<br/>";
+		}
+	}
+
+	if (!validation) {
+		pi.msg.alert("Mancano campi obbligatori:<br/>" + missingFieldsList);
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
C'era un bug nella creazione dei DB, lasciando il campo UID vuoto, portal1 creava un JSON tipo:
{
...
**""**:{...},
...
}
con la chiave vuota.
Ho aggiunto il check di quel campo alla finestra che crea un DB MYSQL, e se me lo approvi aggiungo il controllo anche alle altre finestre di creazione dei DB 🤓 